### PR TITLE
Add return type to python DI files

### DIFF
--- a/src/main/java/org/fever/GotoPypendencyOrCodeHandler.java
+++ b/src/main/java/org/fever/GotoPypendencyOrCodeHandler.java
@@ -225,7 +225,7 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
                 "from django.conf import settings\n" +
                 "\n" +
                 "\n" +
-                "def load(container_builder: ContainerBuilder):\n" +
+                "def load(container_builder: ContainerBuilder) -> None:\n" +
                 "    container_builder.set_definition(\n" +
                 "        Definition(\n" +
                 "            \"" + fqn + "\",\n" +


### PR DESCRIPTION
This PR adds the `-> None` missing in the template for new `.py` DI files, as it triggers MyPy errors in some repos where typing is more strict.