### PR TITLE
Add support for following identifier references

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,9 @@ dependencies {
 intellij {
     version='2023.3'
     type='PY'
-    plugins=['yaml']
+    plugins=['yaml', 'Pythonid']
     pluginName='pycharm-pypendency'
+    downloadSources=false
 }
 patchPluginXml {
     changeNotes="Version 2023.3<br>Go to pypendency."

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -2,7 +2,6 @@ package org.fever;
 
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.*;
-import org.fever.utils.CaseFormatter;
 import org.fever.utils.SourceCodeFileResolver;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -1,0 +1,73 @@
+package org.fever;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.*;
+import org.fever.utils.CaseFormatter;
+import org.fever.utils.SourceCodeFileResolver;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Arrays;
+
+public class PsiReference extends PsiReferenceBase<PsiElement> {
+
+    private final String fqn;
+
+    public PsiReference(@NotNull PsiElement element, TextRange textRange, String fqn) {
+        super(element, textRange);
+
+        this.fqn = this.cleanFqn(fqn);
+    }
+
+    private String cleanFqn(String fqn) {
+        return fqn.replaceAll("[\"'@]", "");
+    }
+
+    @Override
+    public @Nullable PsiElement resolve() {
+        PsiManager psiManager = getElement().getManager();
+        PsiElement sourceCodeFile = SourceCodeFileResolver.fromFqn(fqn, psiManager);
+        if (sourceCodeFile == null && this.fqnMatchesFileName(fqn)) {
+            sourceCodeFile = resolveSourceCodeFileFromCurrentDependencyInjectionFile(psiManager);
+        }
+        if (sourceCodeFile == null) {
+            sourceCodeFile = resolveToFqnsDependencyInjectionFile(fqn, psiManager);
+        }
+
+        return sourceCodeFile;
+    }
+
+    private boolean fqnMatchesFileName(String fqn) {
+        String fqnClassName = fqn.substring(fqn.lastIndexOf(".") + 1);
+        String equivalentClassName = CaseFormatter.camelCaseToSnakeCase(fqnClassName) + ".py";
+        String fileName = getElement().getContainingFile().getName();
+        return equivalentClassName.equals(fileName);
+    }
+
+    private @Nullable PsiElement resolveSourceCodeFileFromCurrentDependencyInjectionFile(PsiManager psiManager) {
+        String dependencyInjectionFilePath = getElement().getContainingFile().getVirtualFile().getCanonicalPath();
+        assert dependencyInjectionFilePath != null;
+        return SourceCodeFileResolver.fromDependencyInjectionFilePath(dependencyInjectionFilePath, psiManager);
+    }
+
+    private @Nullable PsiElement resolveToFqnsDependencyInjectionFile(String fqn, PsiManager psiManager) {
+        String absoluteDependencyInjectionFilePath = this.getAbsoluteDependencyInjectionFilePath(fqn);
+        return SourceCodeFileResolver.getFileFromAbsolutePath(absoluteDependencyInjectionFilePath, psiManager);
+    }
+
+    private String getAbsoluteDependencyInjectionFilePath(String fqn) {
+        // Input: core.infrastructure.user.finders.core_user_finder.CoreUserFinder
+        // Output: core/_dependency_injection/infrastructure/user/finders/core_user_finder.py
+
+        String projectPath = getElement().getProject().getBasePath();
+        String[] parts = fqn.split("\\.");
+        String djangoAppName = parts[0];
+        String relativeFilePath = String.join("/", Arrays.copyOfRange(parts, 1, parts.length - 1));
+        return projectPath + "/src/" + djangoAppName + GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER + relativeFilePath + ".py";
+    }
+
+    @Override
+    public @NotNull String getCanonicalText() {
+        return fqn;
+    }
+}

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -25,32 +25,13 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
     @Override
     public @Nullable PsiElement resolve() {
         PsiManager psiManager = getElement().getManager();
-        PsiElement file = null;
+        PsiElement file = resolveToFqnsDependencyInjectionFile(fqn, psiManager);
 
-        if (this.fqnMatchesFileName(fqn)) {
-            file = resolveSourceCodeFileFromCurrentDependencyInjectionFile(psiManager);
-        }
-        if (file == null) {
-            file = resolveToFqnsDependencyInjectionFile(fqn, psiManager);
-        }
         if (file == null) {
             file = SourceCodeFileResolver.fromFqn(fqn, psiManager);
         }
 
         return file;
-    }
-
-    private boolean fqnMatchesFileName(String fqn) {
-        String fqnClassName = fqn.substring(fqn.lastIndexOf(".") + 1);
-        String equivalentClassName = CaseFormatter.camelCaseToSnakeCase(fqnClassName) + ".py";
-        String fileName = getElement().getContainingFile().getName();
-        return equivalentClassName.equals(fileName);
-    }
-
-    private @Nullable PsiElement resolveSourceCodeFileFromCurrentDependencyInjectionFile(PsiManager psiManager) {
-        String dependencyInjectionFilePath = getElement().getContainingFile().getVirtualFile().getCanonicalPath();
-        assert dependencyInjectionFilePath != null;
-        return SourceCodeFileResolver.fromDependencyInjectionFilePath(dependencyInjectionFilePath, psiManager);
     }
 
     private @Nullable PsiElement resolveToFqnsDependencyInjectionFile(String fqn, PsiManager psiManager) {
@@ -74,10 +55,15 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
         return null;
     }
 
+    /**
+     * Gets the absolute file path of the DI file without the file extension.
+     * For example:
+     *     fqn: core.infrastructure.user.finders.core_user_finder.CoreUserFinder
+     *     return: <PROJECT_PATH>/src/core/_dependency_injection/infrastructure/user/finders/core_user_finder
+     * @param fqn full qualified name of the class.
+     * @return string with the full path of the DI file without the file extension.
+     */
     private String getAbsoluteDependencyInjectionFilePathWithoutExtension(String fqn) {
-        // Input: core.infrastructure.user.finders.core_user_finder.CoreUserFinder
-        // Output: core/_dependency_injection/infrastructure/user/finders/core_user_finder
-
         String absoluteBasePath = getElement().getProject().getBasePath();
         String[] parts = fqn.split("\\.");
         String djangoAppName = parts[0];

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -25,19 +25,19 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
     @Override
     public @Nullable PsiElement resolve() {
         PsiManager psiManager = getElement().getManager();
-        PsiElement sourceCodeFile = null;
+        PsiElement file = null;
 
         if (this.fqnMatchesFileName(fqn)) {
-            sourceCodeFile = resolveSourceCodeFileFromCurrentDependencyInjectionFile(psiManager);
+            file = resolveSourceCodeFileFromCurrentDependencyInjectionFile(psiManager);
         }
-        if (sourceCodeFile == null) {
-            sourceCodeFile = resolveToFqnsDependencyInjectionFile(fqn, psiManager);
+        if (file == null) {
+            file = resolveToFqnsDependencyInjectionFile(fqn, psiManager);
         }
-        if (sourceCodeFile == null) {
-            sourceCodeFile = SourceCodeFileResolver.fromFqn(fqn, psiManager);
+        if (file == null) {
+            file = SourceCodeFileResolver.fromFqn(fqn, psiManager);
         }
 
-        return sourceCodeFile;
+        return file;
     }
 
     private boolean fqnMatchesFileName(String fqn) {

--- a/src/main/java/org/fever/PythonReferenceContributor.java
+++ b/src/main/java/org/fever/PythonReferenceContributor.java
@@ -1,19 +1,16 @@
 package org.fever;
 
 import com.intellij.patterns.PlatformPatterns;
-import com.intellij.psi.PsiLiteralValue;
-import com.intellij.psi.PsiReferenceContributor;
-import com.intellij.psi.PsiReferenceRegistrar;
+import com.intellij.psi.*;
 
 public class PythonReferenceContributor extends PsiReferenceContributor {
     @Override
     public void registerReferenceProviders(PsiReferenceRegistrar registrar) {
         registrar.registerReferenceProvider(
                 PlatformPatterns.psiElement(PsiLiteralValue.class)
-                .inFile(PlatformPatterns.psiFile()
-                .withName(PlatformPatterns.string().endsWith(".py"))
-                ),
-                new ReferenceProvider()
-                );
+                        .inFile(PlatformPatterns.psiFile()
+                        ),
+                new PythonReferenceProvider()
+        );
     }
 }

--- a/src/main/java/org/fever/PythonReferenceContributor.java
+++ b/src/main/java/org/fever/PythonReferenceContributor.java
@@ -1,0 +1,19 @@
+package org.fever;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.PsiLiteralValue;
+import com.intellij.psi.PsiReferenceContributor;
+import com.intellij.psi.PsiReferenceRegistrar;
+
+public class PythonReferenceContributor extends PsiReferenceContributor {
+    @Override
+    public void registerReferenceProviders(PsiReferenceRegistrar registrar) {
+        registrar.registerReferenceProvider(
+                PlatformPatterns.psiElement(PsiLiteralValue.class)
+                .inFile(PlatformPatterns.psiFile()
+                .withName(PlatformPatterns.string().endsWith(".py"))
+                ),
+                new ReferenceProvider()
+                );
+    }
+}

--- a/src/main/java/org/fever/PythonReferenceProvider.java
+++ b/src/main/java/org/fever/PythonReferenceProvider.java
@@ -1,0 +1,52 @@
+package org.fever;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.util.QualifiedName;
+import com.intellij.util.ProcessingContext;
+import com.jetbrains.python.psi.PyCallExpression;
+import com.jetbrains.python.psi.impl.PyReferenceExpressionImpl;
+import org.jetbrains.annotations.NotNull;
+
+import static org.fever.GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER;
+
+
+public class PythonReferenceProvider extends ReferenceProvider {
+    @Override
+    public com.intellij.psi.PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+        String text = cleanText(element.getText());
+
+        if (isInDependencyInjectionFile(element)) {
+            if (text.startsWith("@")) {
+                return getReferenceForIdentifierAsArray(element, text);
+            }
+        } else if (isInContainerBuilderGet(element)) {
+            return getReferenceForIdentifierAsArray(element, text);
+        }
+        return PsiReference.EMPTY_ARRAY;
+    }
+
+    private static boolean isInDependencyInjectionFile(@NotNull PsiElement element) {
+        String absoluteFilePath = element.getContainingFile().getVirtualFile().getCanonicalPath();
+        if (absoluteFilePath == null) {
+            return false;
+        }
+        return absoluteFilePath.contains(DEPENDENCY_INJECTION_FOLDER);
+    }
+
+    private static com.intellij.psi.PsiReference @NotNull [] getReferenceForIdentifierAsArray(@NotNull PsiElement element, String text) {
+        PsiReference reference = getReferenceForIdentifier(element, text);
+        return new PsiReference[]{reference};
+    }
+    private boolean isInContainerBuilderGet(PsiElement element) {
+        PsiElement grandParent = element.getParent().getParent();
+        if (!(grandParent instanceof PyCallExpression)) {
+            return false;
+        }
+        QualifiedName qualifiedName = ((PyReferenceExpressionImpl) grandParent.getFirstChild()).asQualifiedName();
+        if (qualifiedName == null) {
+            return false;
+        }
+
+        return qualifiedName.toString().equals("container_builder.get");
+    }
+}

--- a/src/main/java/org/fever/ReferenceProvider.java
+++ b/src/main/java/org/fever/ReferenceProvider.java
@@ -8,21 +8,20 @@ import org.fever.utils.FqnExtractor;
 import org.jetbrains.annotations.NotNull;
 
 public class ReferenceProvider extends PsiReferenceProvider {
-
     @Override
     public com.intellij.psi.PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
         String text = element.getText();
         if (!text.matches(FqnExtractor.FQN_REGEX)) {
-            return new com.intellij.psi.PsiReference[0];
+            return org.fever.PsiReference.EMPTY_ARRAY;
         }
 
-        com.intellij.psi.PsiReference reference = getReferenceForFqn(element, text);
+        org.fever.PsiReference reference = getReferenceForFqn(element, text);
 
-        return new com.intellij.psi.PsiReference[]{reference};
+        return new org.fever.PsiReference[]{reference};
     }
 
     @NotNull
-    private static com.intellij.psi.PsiReference getReferenceForFqn(@NotNull PsiElement element, String fqn) {
+    private static org.fever.PsiReference getReferenceForFqn(@NotNull PsiElement element, String fqn) {
         TextRange range;
         if (hasQuotes(fqn)) {
              range = new TextRange(1, fqn.length() - 1);
@@ -30,7 +29,7 @@ public class ReferenceProvider extends PsiReferenceProvider {
             range = new TextRange(0, fqn.length());
         }
 
-        return new PsiReference(element, range, fqn);
+        return new org.fever.PsiReference(element, range, fqn);
     }
 
     private static boolean hasQuotes(String fqn) {

--- a/src/main/java/org/fever/ReferenceProvider.java
+++ b/src/main/java/org/fever/ReferenceProvider.java
@@ -3,37 +3,19 @@ package org.fever;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReferenceProvider;
-import com.intellij.util.ProcessingContext;
 import org.jetbrains.annotations.NotNull;
 
-public class ReferenceProvider extends PsiReferenceProvider {
-    public static final String IDENTIFIER_REGEX = "^\"?@?[a-z0-9_.]+\\.[A-Za-z0-9_]+\"?$";
-
-    @Override
-    public com.intellij.psi.PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
-        String text = element.getText();
-        if (!text.matches(IDENTIFIER_REGEX)) {
-            return org.fever.PsiReference.EMPTY_ARRAY;
-        }
-
-        org.fever.PsiReference reference = getReferenceForIdentifier(element, text);
-
-        return new org.fever.PsiReference[]{reference};
+public abstract class ReferenceProvider extends PsiReferenceProvider {
+    @NotNull
+    protected String cleanText(String text) {
+        return text.replaceAll("[\"']", "");
     }
 
     @NotNull
-    private static org.fever.PsiReference getReferenceForIdentifier(@NotNull PsiElement element, String identifier) {
+    protected static org.fever.PsiReference getReferenceForIdentifier(@NotNull PsiElement element, String identifier) {
         TextRange range;
-        if (hasQuotes(identifier)) {
-             range = new TextRange(1, identifier.length() - 1);
-        } else {
-            range = new TextRange(0, identifier.length());
-        }
-
+        int offset = element.getText().contains("@") ? 1 : 0;
+        range = new TextRange(offset, identifier.length() + offset);
         return new org.fever.PsiReference(element, range, identifier);
-    }
-
-    private static boolean hasQuotes(String fqn) {
-        return fqn.matches("^[\"'].*[\"']$");
     }
 }

--- a/src/main/java/org/fever/ReferenceProvider.java
+++ b/src/main/java/org/fever/ReferenceProvider.java
@@ -1,0 +1,39 @@
+package org.fever;
+
+import com.intellij.openapi.util.TextRange;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReferenceProvider;
+import com.intellij.util.ProcessingContext;
+import org.fever.utils.FqnExtractor;
+import org.jetbrains.annotations.NotNull;
+
+public class ReferenceProvider extends PsiReferenceProvider {
+
+    @Override
+    public com.intellij.psi.PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+        String text = element.getText();
+        if (!text.matches(FqnExtractor.FQN_REGEX)) {
+            return new com.intellij.psi.PsiReference[0];
+        }
+
+        com.intellij.psi.PsiReference reference = getReferenceForFqn(element, text);
+
+        return new com.intellij.psi.PsiReference[]{reference};
+    }
+
+    @NotNull
+    private static com.intellij.psi.PsiReference getReferenceForFqn(@NotNull PsiElement element, String fqn) {
+        TextRange range;
+        if (hasQuotes(fqn)) {
+             range = new TextRange(1, fqn.length() - 1);
+        } else {
+            range = new TextRange(0, fqn.length());
+        }
+
+        return new PsiReference(element, range, fqn);
+    }
+
+    private static boolean hasQuotes(String fqn) {
+        return fqn.matches("^[\"'].*[\"']$");
+    }
+}

--- a/src/main/java/org/fever/ReferenceProvider.java
+++ b/src/main/java/org/fever/ReferenceProvider.java
@@ -4,32 +4,33 @@ import com.intellij.openapi.util.TextRange;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiReferenceProvider;
 import com.intellij.util.ProcessingContext;
-import org.fever.utils.FqnExtractor;
 import org.jetbrains.annotations.NotNull;
 
 public class ReferenceProvider extends PsiReferenceProvider {
+    public static final String IDENTIFIER_REGEX = "^\"?@?[a-z0-9_.]+\\.[A-Za-z0-9_]+\"?$";
+
     @Override
     public com.intellij.psi.PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
         String text = element.getText();
-        if (!text.matches(FqnExtractor.FQN_REGEX)) {
+        if (!text.matches(IDENTIFIER_REGEX)) {
             return org.fever.PsiReference.EMPTY_ARRAY;
         }
 
-        org.fever.PsiReference reference = getReferenceForFqn(element, text);
+        org.fever.PsiReference reference = getReferenceForIdentifier(element, text);
 
         return new org.fever.PsiReference[]{reference};
     }
 
     @NotNull
-    private static org.fever.PsiReference getReferenceForFqn(@NotNull PsiElement element, String fqn) {
+    private static org.fever.PsiReference getReferenceForIdentifier(@NotNull PsiElement element, String identifier) {
         TextRange range;
-        if (hasQuotes(fqn)) {
-             range = new TextRange(1, fqn.length() - 1);
+        if (hasQuotes(identifier)) {
+             range = new TextRange(1, identifier.length() - 1);
         } else {
-            range = new TextRange(0, fqn.length());
+            range = new TextRange(0, identifier.length());
         }
 
-        return new org.fever.PsiReference(element, range, fqn);
+        return new org.fever.PsiReference(element, range, identifier);
     }
 
     private static boolean hasQuotes(String fqn) {

--- a/src/main/java/org/fever/YamlReferenceContributor.java
+++ b/src/main/java/org/fever/YamlReferenceContributor.java
@@ -10,7 +10,7 @@ public class YamlReferenceContributor extends PsiReferenceContributor {
                 PlatformPatterns.psiElement()
                 .inFile(PlatformPatterns.psiFile()
                 ),
-                new ReferenceProvider()
+                new YamlReferenceProvider()
         );
     }
 }

--- a/src/main/java/org/fever/YamlReferenceContributor.java
+++ b/src/main/java/org/fever/YamlReferenceContributor.java
@@ -1,0 +1,16 @@
+package org.fever;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.psi.*;
+
+public class YamlReferenceContributor extends PsiReferenceContributor {
+    @Override
+    public void registerReferenceProviders(PsiReferenceRegistrar registrar) {
+        registrar.registerReferenceProvider(
+                PlatformPatterns.psiElement()
+                .inFile(PlatformPatterns.psiFile()
+                ),
+                new ReferenceProvider()
+        );
+    }
+}

--- a/src/main/java/org/fever/YamlReferenceProvider.java
+++ b/src/main/java/org/fever/YamlReferenceProvider.java
@@ -1,0 +1,20 @@
+package org.fever;
+
+import com.intellij.psi.PsiElement;
+import com.intellij.util.ProcessingContext;
+import org.jetbrains.annotations.NotNull;
+
+
+public class YamlReferenceProvider extends ReferenceProvider {
+    protected static final String IDENTIFIER_REGEX = "^@[a-z0-9_.]+\\.[A-Za-z0-9_]+$";
+
+    @Override
+    public com.intellij.psi.PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+        String text = cleanText(element.getText());
+        if (text.matches(IDENTIFIER_REGEX)) {
+            PsiReference reference = getReferenceForIdentifier(element, text);
+            return new PsiReference[]{reference};
+        }
+        return PsiReference.EMPTY_ARRAY;
+    }
+}

--- a/src/main/java/org/fever/utils/FqnExtractor.java
+++ b/src/main/java/org/fever/utils/FqnExtractor.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FqnExtractor {
-    public static final String FQN_REGEX = "^\"?@?[a-z0-9_.]+\\.[A-Z]+[a-zA-Z]+\"?$";
+    public static final String FQN_REGEX = "^\"?@?[a-z0-9_.]+\\.[A-Za-z0-9_]+\"?$";
     private static final String YAML_FQN_GROUP_SELECTOR_REGEX = "fqn:\\s*(\\S+)";
     private static final String PYTHON_FQN_GROUP_SELECTOR_REGEX = "container_builder\\.set_definition\\(\\s+Definition\\(\\s*\"\\S+\",\\s*\"(\\S+)\"";
 

--- a/src/main/java/org/fever/utils/FqnExtractor.java
+++ b/src/main/java/org/fever/utils/FqnExtractor.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FqnExtractor {
+    public static final String FQN_REGEX = "^\"?@?[a-z_.]+\\.[A-Z]+[a-zA-Z]+\"?$";
     private static final String YAML_FQN_GROUP_SELECTOR_REGEX = "fqn:\\s*(\\S+)";
     private static final String PYTHON_FQN_GROUP_SELECTOR_REGEX = "container_builder\\.set_definition\\(\\s+Definition\\(\\s*\"\\S+\",\\s*\"(\\S+)\"";
 

--- a/src/main/java/org/fever/utils/FqnExtractor.java
+++ b/src/main/java/org/fever/utils/FqnExtractor.java
@@ -6,7 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FqnExtractor {
-    public static final String FQN_REGEX = "^\"?@?[a-z_.]+\\.[A-Z]+[a-zA-Z]+\"?$";
+    public static final String FQN_REGEX = "^\"?@?[a-z0-9_.]+\\.[A-Z]+[a-zA-Z]+\"?$";
     private static final String YAML_FQN_GROUP_SELECTOR_REGEX = "fqn:\\s*(\\S+)";
     private static final String PYTHON_FQN_GROUP_SELECTOR_REGEX = "container_builder\\.set_definition\\(\\s+Definition\\(\\s*\"\\S+\",\\s*\"(\\S+)\"";
 

--- a/src/main/java/org/fever/utils/FqnExtractor.java
+++ b/src/main/java/org/fever/utils/FqnExtractor.java
@@ -6,7 +6,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class FqnExtractor {
-    public static final String FQN_REGEX = "^\"?@?[a-z0-9_.]+\\.[A-Za-z0-9_]+\"?$";
     private static final String YAML_FQN_GROUP_SELECTOR_REGEX = "fqn:\\s*(\\S+)";
     private static final String PYTHON_FQN_GROUP_SELECTOR_REGEX = "container_builder\\.set_definition\\(\\s+Definition\\(\\s*\"\\S+\",\\s*\"(\\S+)\"";
 

--- a/src/main/java/org/fever/utils/SourceCodeFileResolver.java
+++ b/src/main/java/org/fever/utils/SourceCodeFileResolver.java
@@ -33,22 +33,6 @@ public class SourceCodeFileResolver {
         return CaseFormatter.camelCaseToSnakeCase(className);
     }
 
-    public static @Nullable PsiFile fromDependencyInjectionFilePath(String absoluteDependencyInjectionFilePath, PsiManager psiManager) {
-        if (!fileIsInDependencyInjectionFolder(absoluteDependencyInjectionFilePath)) {
-            return null;
-        }
-
-        String sourceCodeFilePath = absoluteDependencyInjectionFilePath
-                .replace(GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER, "/")
-                .replaceAll("\\.y(a)?ml", ".py");
-
-        return getFileFromAbsolutePath(sourceCodeFilePath, psiManager);
-    }
-
-    private static Boolean fileIsInDependencyInjectionFolder(String filePath) {
-        return filePath.contains(GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER);
-    }
-
     public static @Nullable PsiFile getFileFromAbsolutePath(String absolutePath, PsiManager psiManager) {
         VirtualFile file = LocalFileSystem.getInstance().findFileByPath(absolutePath);
         if (file != null) {

--- a/src/main/java/org/fever/utils/SourceCodeFileResolver.java
+++ b/src/main/java/org/fever/utils/SourceCodeFileResolver.java
@@ -4,6 +4,7 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
+import org.fever.GotoPypendencyOrCodeHandler;
 import org.jetbrains.annotations.Nullable;
 
 public class SourceCodeFileResolver {
@@ -30,6 +31,22 @@ public class SourceCodeFileResolver {
         String[] parts = fqn.split("\\.");
         String className = parts[parts.length - 1];
         return CaseFormatter.camelCaseToSnakeCase(className);
+    }
+
+    public static @Nullable PsiFile fromDependencyInjectionFilePath(String absoluteDependencyInjectionFilePath, PsiManager psiManager) {
+        if (!fileIsInDependencyInjectionFolder(absoluteDependencyInjectionFilePath)) {
+            return null;
+        }
+
+        String sourceCodeFilePath = absoluteDependencyInjectionFilePath
+                .replace(GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER, "/")
+                .replaceAll("\\.y(a)?ml", ".py");
+
+        return getFileFromAbsolutePath(sourceCodeFilePath, psiManager);
+    }
+
+    private static Boolean fileIsInDependencyInjectionFolder(String filePath) {
+        return filePath.contains(GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER);
     }
 
     public static @Nullable PsiFile getFileFromAbsolutePath(String absolutePath, PsiManager psiManager) {

--- a/src/main/java/org/fever/utils/SourceCodeFileResolver.java
+++ b/src/main/java/org/fever/utils/SourceCodeFileResolver.java
@@ -4,7 +4,6 @@ import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
-import org.fever.GotoPypendencyOrCodeHandler;
 import org.jetbrains.annotations.Nullable;
 
 public class SourceCodeFileResolver {

--- a/src/main/java/org/fever/utils/SourceCodeFileResolver.java
+++ b/src/main/java/org/fever/utils/SourceCodeFileResolver.java
@@ -27,7 +27,7 @@ public class SourceCodeFileResolver {
         return null;
     }
 
-    private static String getClassNameInSnakeCase(String fqn) {
+    public static String getClassNameInSnakeCase(String fqn) {
         String[] parts = fqn.split("\\.");
         String className = parts[parts.length - 1];
         return CaseFormatter.camelCaseToSnakeCase(className);

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,11 @@
 <!--        <completion.contributor language="yaml" implementationClass="org.fever.YamlCompletionContributor"/>-->
 <!--    </extensions>-->
 
+    <extensions defaultExtensionNs="com.intellij">
+        <psi.referenceContributor language="yaml" implementation="org.fever.YamlReferenceContributor"/>
+        <psi.referenceContributor implementation="org.fever.PythonReferenceContributor"/>
+    </extensions>
+
     <actions>
         <group id="PypendencyGroup" popup="true" text="Pypendency">
             <add-to-group group-id="GoToCodeGroup" anchor="after" relative-to-action="GotoTest"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -30,6 +30,7 @@
          on how to target different products -->
     <depends>com.intellij.modules.platform</depends>
     <depends>com.intellij.modules.lang</depends>
+    <depends>com.intellij.modules.python</depends>
     <depends>org.jetbrains.plugins.yaml</depends>
 
 <!--    <extensions defaultExtensionNs="com.intellij">-->
@@ -38,7 +39,7 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <psi.referenceContributor language="yaml" implementation="org.fever.YamlReferenceContributor"/>
-        <psi.referenceContributor implementation="org.fever.PythonReferenceContributor"/>
+        <psi.referenceContributor language="Python" implementation="org.fever.PythonReferenceContributor"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
Main PR: https://github.com/josemoren/pycharm-pypendency-plugin/pull/3

### ℹ️  What does this PR do?

This PR adds the following:
* Support for Python language (necessary for references in .py files)
* Support for following identifier references, both in YAML files and in python ones.

### 📖  Summary

This allows to ctrl/cmd + click on a reference to navigate to its DI file. In case the DI file is not found, it **navigates to the source code** as a **fallback**. This is useful to identify those cases in which the DI file is not in the correct folder. In those cases, the class has an associated DI file but the pypendency plugin prompts to create a new DI file when invoked.

This mechanism currently supports trivial resolutions: Take the file path, add `/_dependency_injection` after the Django package name and try to find a file matching the pattern in order of [most commonly used](https://github.com/josemoren/pycharm-pypendency-plugin/blob/1bded9e0a0acb5c6faeefe215877a10f6e298ffc/src/main/java/org/fever/PsiReference.java#L73-L80). In a future PR, I intend to add a fallback for a more exhaustive search in case the DI file can't be easily deduced (Find occurences of `container_builder.set(<identifier>)`)