### PR TITLE
Follow references by manually setting FQN as final fallback

### DIFF
--- a/src/main/java/org/fever/DependencyInjectionSearchScope.java
+++ b/src/main/java/org/fever/DependencyInjectionSearchScope.java
@@ -1,0 +1,33 @@
+package org.fever;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.search.GlobalSearchScope;
+import org.jetbrains.annotations.NotNull;
+
+public class DependencyInjectionSearchScope extends GlobalSearchScope {
+
+    public DependencyInjectionSearchScope(@NotNull Project project) {
+        super(project);
+    }
+
+    @Override
+    public boolean contains(@NotNull VirtualFile file) {
+        return file.getPath().contains("/_dependency_injection") && file.getName().endsWith(".py");
+    }
+
+    @Override
+    public int compare(@NotNull VirtualFile file1, @NotNull VirtualFile file2) {
+        return 0;
+    }
+
+    @Override
+    public boolean isSearchInModuleContent(@NotNull com.intellij.openapi.module.Module aModule) {
+        return true;
+    }
+
+    @Override
+    public boolean isSearchInLibraries() {
+        return false;
+    }
+}

--- a/src/main/java/org/fever/DependencyInjectionSearchScope.java
+++ b/src/main/java/org/fever/DependencyInjectionSearchScope.java
@@ -13,7 +13,7 @@ public class DependencyInjectionSearchScope extends GlobalSearchScope {
 
     @Override
     public boolean contains(@NotNull VirtualFile file) {
-        return file.getPath().contains("/_dependency_injection") && file.getName().endsWith(".py");
+        return file.getPath().contains(GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER) && file.getName().endsWith(".py");
     }
 
     @Override

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -17,8 +17,10 @@ import java.util.regex.Pattern;
 
 public class PsiReference extends PsiReferenceBase<PsiElement> {
     private final String identifier;
-    private static final String MANUALLY_SET_FQN_GROUP_SELECTOR_REGEX = "container_builder\\.set\\(\\s*\"(\\S+)\"";
-
+    private static final String[] REGEX_FOR_MANUALLY_SET_IDENTIFIERS = {
+            "container_builder\\.set\\(\\s*\"(\\S+)\"",
+            "container_builder\\.set_definition\\(\\s*Definition\\(\\s*\"(\\S+)\"",
+    };
     public PsiReference(@NotNull PsiElement element, TextRange textRange, String identifier) {
         super(element, textRange);
 
@@ -96,9 +98,11 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
             PsiFile psiFile = psiManager.findFile(file);
             assert psiFile != null;
             String fileContent = psiFile.getText();
-            Matcher matcher = Pattern.compile(MANUALLY_SET_FQN_GROUP_SELECTOR_REGEX).matcher(fileContent);
-            if (matcher.find() && matcher.group(1).equals(identifier)) {
-                return psiFile;
+            for (String regex : REGEX_FOR_MANUALLY_SET_IDENTIFIERS) {
+                Matcher matcher = Pattern.compile(regex).matcher(fileContent);
+                if (matcher.find() && matcher.group(1).equals(identifier)) {
+                    return psiFile;
+                }
             }
         }
         return null;

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -94,12 +94,13 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
                         PythonFileType.INSTANCE,
                         scope);
 
-        for (VirtualFile file : dependencyInjectionFiles) {
-            PsiFile psiFile = psiManager.findFile(file);
-            assert psiFile != null;
-            String fileContent = psiFile.getText();
-            for (String regex : REGEX_FOR_MANUALLY_SET_IDENTIFIERS) {
-                Matcher matcher = Pattern.compile(regex).matcher(fileContent);
+        for (String regex : REGEX_FOR_MANUALLY_SET_IDENTIFIERS) {
+            Matcher matcher = Pattern.compile(regex).matcher("");
+            for (VirtualFile file : dependencyInjectionFiles) {
+                PsiFile psiFile = psiManager.findFile(file);
+                assert psiFile != null;
+                String fileContent = psiFile.getText();
+                matcher.reset(fileContent);
                 if (matcher.find() && matcher.group(1).equals(identifier)) {
                     return psiFile;
                 }


### PR DESCRIPTION
Main PR: https://github.com/josemoren/pycharm-pypendency-plugin/pull/3

## ✋ Don't merge until the base branch is merged

This PR makes following references (cmd+click) more exhaustive. It will try to find a matching file in the following order:
1. If we are in a DI file and we cmd+click the FQN of the own class, it will take us to its **source code definition**, as the new `Pypendency: Go to code` shortcut does
2. Otherwise, it will try to **find a file in the project that matches the FQN**. Unfortunately, not all of them have the name they should (with the name of the class file at the end), and they can be in different formats (.yaml, .py or even .yml) Since these are sometimes defined in a less structured way, we will try to find a file matching a list of possible paths, trying first the ones that are most common (.yaml files created by the Pypendency plugin), in order to minimize the latency.
3. If the file cannot be found, it will try to **find occurences** in all the `.py` files in the project which are inside a `/_dependency_injection` subfolder for a FQN matching `container_builder.set("<fqn>")`, or in case it doesn't find one, it will try to find a definition with `container_builder.set_definition(Definition("<fqn>")`
4. If none of the previous were successful, it will try to **open the source code file**. This should only happen in cases in which the FQN is defined in a `.yaml` file which does not match the folder structure, probably because someone moved the original class during a refactor and forgot to move the DI file too.

The behavior might seem a bit erratic (following the reference takes the dev to the DI file in some cases and to the source code in others), but it's the plugin making a "best effort" to give the dev the most useful file. This is open for discussion, as we might want to raise a warning in cases like **4.** to let the developers know that there's a DI file that needs to be renamed because it does not match the folder structure anymore.