### PR TITLE
Resolve FQN to itself when no matches

### DIFF
--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -35,7 +35,8 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
 
     @Override
     public @Nullable PsiElement resolve() {
-        PsiManager psiManager = getElement().getManager();
+        PsiElement thisElement = getElement();
+        PsiManager psiManager = thisElement.getManager();
         PsiElement file = null;
 
         if (this.fqnMatchesFileName(fqn)) {
@@ -49,6 +50,9 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
         }
         if (file == null) {
             file = SourceCodeFileResolver.fromFqn(fqn, psiManager);
+        }
+        if (file == null) {
+            file = thisElement.getContainingFile();
         }
 
         return file;


### PR DESCRIPTION
## ✋ Don't merge until the base branch is merged

This PR prevents PyCharm from marking as errors those FQNs that can't be resolved to DI files, making a red underline appear under them. This was being an issue, as it was marking as errors some stuff as command/queries FQNs or things like `"foo.return_value"` in tests.

The way we are tackling this problem is by resolving references to their own file in case there are no matches. In a future, we could think of a better way of identify FQNs (i.e., exclude test, command and query files), but that could be tailoring the plugin too much to some of our projects.

### How should this be tested? 🤔 
### Before you start...
- [ ] Open IntelliJ Idea
- [ ] Checkout this branch
- [ ] Select and run the `[runIde]` configuration:

<img width="582" alt="image" src="https://github.com/josemoren/pycharm-pypendency-plugin/assets/53608787/bf4c8efd-3d10-48c5-90f9-d43398e1e2b7">

### IDE 💡
- Go to a `*_command.py` DI file, and try to ⌘+click to its manually-defined FQN
- Check that it's highlighted, and when clicked doesn't do anything (it's treated as a FQN whose resolution is in the own file)
- Go to a `test_*.py` file and check that the same occurs with any FQN-like string without a DI resolution (e.g., those FQNs in `@patch(<fqn>)`)
