### PR TITLE
Fix issues with identifiers without dots

### DIFF
--- a/src/main/java/org/fever/DependencyInjectionSearchScope.java
+++ b/src/main/java/org/fever/DependencyInjectionSearchScope.java
@@ -13,7 +13,20 @@ public class DependencyInjectionSearchScope extends GlobalSearchScope {
 
     @Override
     public boolean contains(@NotNull VirtualFile file) {
-        return file.getPath().contains(GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER) && file.getName().endsWith(".py");
+        String filePath = file.getPath();
+        return isPythonFile(file) && fileIsInDependencyInjectionFolder(filePath) && fileIsNotInExternalLibraries(filePath);
+    }
+
+    private static boolean fileIsInDependencyInjectionFolder(String filePath) {
+        return filePath.contains(GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER);
+    }
+
+    private static boolean isPythonFile(@NotNull VirtualFile file) {
+        return file.getName().endsWith(".py");
+    }
+
+    private static boolean fileIsNotInExternalLibraries(String filePath) {
+        return !filePath.contains("/remote_sources/");
     }
 
     @Override
@@ -23,7 +36,7 @@ public class DependencyInjectionSearchScope extends GlobalSearchScope {
 
     @Override
     public boolean isSearchInModuleContent(@NotNull com.intellij.openapi.module.Module aModule) {
-        return true;
+        return false;
     }
 
     @Override

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -80,6 +80,9 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
     private String getAbsoluteDependencyInjectionFileDirectory(String identifier) {
         String absoluteBasePath = getElement().getProject().getBasePath();
         String[] parts = identifier.split("\\.");
+        if (parts.length < 2) {
+            return "";
+        }
         String djangoAppName = parts[0];
         String relativeFilePath = String.join("/", Arrays.copyOfRange(parts, 1, parts.length - 1));
 

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -18,7 +18,7 @@ import java.util.regex.Pattern;
 public class PsiReference extends PsiReferenceBase<PsiElement> {
     private final String identifier;
     private static final String[] REGEX_FOR_MANUALLY_SET_IDENTIFIERS = {
-            "container_builder\\.set\\(\\s*\"(\\S+)\"",
+            "container(?:_builder)?\\.set\\(\\s*\"(\\S+)\"",
             "container_builder\\.set_definition\\(\\s*Definition\\(\\s*\"(\\S+)\"",
     };
 
@@ -82,15 +82,9 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
         String absoluteBasePath = getElement().getProject().getBasePath();
         String[] parts = identifier.split("\\.");
         String djangoAppName = parts[0];
-        String relativeFilePath = getRelativeFilePath(identifier, parts);
-        return absoluteBasePath + "/src/" + djangoAppName + GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER + "/" + relativeFilePath;
-    }
+        String relativeFilePath = String.join("/", Arrays.copyOfRange(parts, 1, parts.length - 1));
 
-    private static String getRelativeFilePath(String identifier, String[] parts) {
-        if (parts.length < 2) {
-            return String.join("/", Arrays.copyOfRange(parts, 1, parts.length - 1));
-        }
-        return identifier;
+        return absoluteBasePath + "/src/" + djangoAppName + GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER + relativeFilePath;
     }
 
     private PsiElement resolveToDependencyInjectionManualDeclaration(String identifier, PsiManager psiManager) {

--- a/src/main/java/org/fever/PsiReference.java
+++ b/src/main/java/org/fever/PsiReference.java
@@ -21,6 +21,7 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
             "container_builder\\.set\\(\\s*\"(\\S+)\"",
             "container_builder\\.set_definition\\(\\s*Definition\\(\\s*\"(\\S+)\"",
     };
+
     public PsiReference(@NotNull PsiElement element, TextRange textRange, String identifier) {
         super(element, textRange);
 
@@ -80,13 +81,16 @@ public class PsiReference extends PsiReferenceBase<PsiElement> {
     private String getAbsoluteDependencyInjectionFileDirectory(String identifier) {
         String absoluteBasePath = getElement().getProject().getBasePath();
         String[] parts = identifier.split("\\.");
-        if (parts.length < 2) {
-            return "";
-        }
         String djangoAppName = parts[0];
-        String relativeFilePath = String.join("/", Arrays.copyOfRange(parts, 1, parts.length - 1));
+        String relativeFilePath = getRelativeFilePath(identifier, parts);
+        return absoluteBasePath + "/src/" + djangoAppName + GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER + "/" + relativeFilePath;
+    }
 
-        return absoluteBasePath + "/src/" + djangoAppName + GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER + relativeFilePath;
+    private static String getRelativeFilePath(String identifier, String[] parts) {
+        if (parts.length < 2) {
+            return String.join("/", Arrays.copyOfRange(parts, 1, parts.length - 1));
+        }
+        return identifier;
     }
 
     private PsiElement resolveToDependencyInjectionManualDeclaration(String identifier, PsiManager psiManager) {

--- a/src/main/java/org/fever/PythonReferenceProvider.java
+++ b/src/main/java/org/fever/PythonReferenceProvider.java
@@ -12,6 +12,8 @@ import static org.fever.GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER;
 
 
 public class PythonReferenceProvider extends ReferenceProvider {
+    private static final String IDENTIFIER_REGEX_FOR_CONTAINER_BUILDER_GET = "^[a-z0-9_.]+\\.[A-Za-z0-9_]+$";
+
     @Override
     public com.intellij.psi.PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
         String text = cleanText(element.getText());
@@ -21,7 +23,9 @@ public class PythonReferenceProvider extends ReferenceProvider {
                 return getReferenceForIdentifierAsArray(element, text);
             }
         } else if (isInContainerBuilderGet(element)) {
-            return getReferenceForIdentifierAsArray(element, text);
+            if (text.matches(IDENTIFIER_REGEX_FOR_CONTAINER_BUILDER_GET)) {
+                return getReferenceForIdentifierAsArray(element, text);
+            }
         }
         return PsiReference.EMPTY_ARRAY;
     }

--- a/src/main/java/org/fever/PythonReferenceProvider.java
+++ b/src/main/java/org/fever/PythonReferenceProvider.java
@@ -1,5 +1,6 @@
 package org.fever;
 
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.QualifiedName;
 import com.intellij.util.ProcessingContext;
@@ -16,7 +17,7 @@ public class PythonReferenceProvider extends ReferenceProvider {
         String text = cleanText(element.getText());
 
         if (isInDependencyInjectionFile(element)) {
-            if (hasIdentifierFormat(text)) {
+            if (text.matches(IDENTIFIER_REGEX_FOR_DI_FILES)) {
                 return getReferenceForIdentifierAsArray(element, text);
             }
         } else if (isInContainerBuilderGet(element)) {
@@ -25,12 +26,12 @@ public class PythonReferenceProvider extends ReferenceProvider {
         return PsiReference.EMPTY_ARRAY;
     }
 
-    private static boolean hasIdentifierFormat(String text) {
-        return text.startsWith("@") && text.contains(".");
-    }
-
     private static boolean isInDependencyInjectionFile(@NotNull PsiElement element) {
-        String absoluteFilePath = element.getContainingFile().getVirtualFile().getCanonicalPath();
+        VirtualFile virtualFile = element.getContainingFile().getVirtualFile();
+        if (virtualFile == null) {
+            return false;
+        }
+        String absoluteFilePath = virtualFile.getCanonicalPath();
         if (absoluteFilePath == null) {
             return false;
         }

--- a/src/main/java/org/fever/PythonReferenceProvider.java
+++ b/src/main/java/org/fever/PythonReferenceProvider.java
@@ -16,13 +16,17 @@ public class PythonReferenceProvider extends ReferenceProvider {
         String text = cleanText(element.getText());
 
         if (isInDependencyInjectionFile(element)) {
-            if (text.startsWith("@")) {
+            if (hasIdentifierFormat(text)) {
                 return getReferenceForIdentifierAsArray(element, text);
             }
         } else if (isInContainerBuilderGet(element)) {
             return getReferenceForIdentifierAsArray(element, text);
         }
         return PsiReference.EMPTY_ARRAY;
+    }
+
+    private static boolean hasIdentifierFormat(String text) {
+        return text.startsWith("@") && text.contains(".");
     }
 
     private static boolean isInDependencyInjectionFile(@NotNull PsiElement element) {

--- a/src/main/java/org/fever/ReferenceProvider.java
+++ b/src/main/java/org/fever/ReferenceProvider.java
@@ -6,6 +6,8 @@ import com.intellij.psi.PsiReferenceProvider;
 import org.jetbrains.annotations.NotNull;
 
 public abstract class ReferenceProvider extends PsiReferenceProvider {
+    protected static final String IDENTIFIER_REGEX_FOR_DI_FILES = "^@[a-z0-9_.]+\\.[A-Za-z0-9_]+$";
+
     @NotNull
     protected String cleanText(String text) {
         return text.replaceAll("[\"']", "");

--- a/src/main/java/org/fever/ReferenceProvider.java
+++ b/src/main/java/org/fever/ReferenceProvider.java
@@ -14,8 +14,7 @@ public abstract class ReferenceProvider extends PsiReferenceProvider {
     @NotNull
     protected static org.fever.PsiReference getReferenceForIdentifier(@NotNull PsiElement element, String identifier) {
         TextRange range;
-        int offset = element.getText().contains("@") ? 1 : 0;
-        range = new TextRange(offset, identifier.length() + offset);
+        range = new TextRange(1, identifier.length() + 1);
         return new org.fever.PsiReference(element, range, identifier);
     }
 }

--- a/src/main/java/org/fever/YamlReferenceProvider.java
+++ b/src/main/java/org/fever/YamlReferenceProvider.java
@@ -6,12 +6,10 @@ import org.jetbrains.annotations.NotNull;
 
 
 public class YamlReferenceProvider extends ReferenceProvider {
-    protected static final String IDENTIFIER_REGEX = "^@[a-z0-9_.]+\\.[A-Za-z0-9_]+$";
-
     @Override
     public com.intellij.psi.PsiReference @NotNull [] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
         String text = cleanText(element.getText());
-        if (text.matches(IDENTIFIER_REGEX)) {
+        if (text.matches(IDENTIFIER_REGEX_FOR_DI_FILES)) {
             PsiReference reference = getReferenceForIdentifier(element, text);
             return new PsiReference[]{reference};
         }

--- a/src/main/java/org/fever/utils/SourceCodeFileResolver.java
+++ b/src/main/java/org/fever/utils/SourceCodeFileResolver.java
@@ -8,9 +8,6 @@ import org.jetbrains.annotations.Nullable;
 
 public class SourceCodeFileResolver {
     public static @Nullable PsiFile fromFqn(String fqn, PsiManager psiManager) {
-        if (!fqnHasDots(fqn)) {
-            return null;
-        }
         String fqnWithSlashes = fqn.replace(".", "/");
         String relativeFilePath = fqnWithSlashes.substring(0, fqnWithSlashes.lastIndexOf("/"));
         String absoluteBasePath = psiManager.getProject().getBasePath();
@@ -27,10 +24,6 @@ public class SourceCodeFileResolver {
             }
         }
         return null;
-    }
-
-    private static boolean fqnHasDots(String fqn) {
-        return fqn.contains(".");
     }
 
     public static String getClassNameInSnakeCase(String fqn) {

--- a/src/main/java/org/fever/utils/SourceCodeFileResolver.java
+++ b/src/main/java/org/fever/utils/SourceCodeFileResolver.java
@@ -8,6 +8,9 @@ import org.jetbrains.annotations.Nullable;
 
 public class SourceCodeFileResolver {
     public static @Nullable PsiFile fromFqn(String fqn, PsiManager psiManager) {
+        if (!fqnHasDots(fqn)) {
+            return null;
+        }
         String fqnWithSlashes = fqn.replace(".", "/");
         String relativeFilePath = fqnWithSlashes.substring(0, fqnWithSlashes.lastIndexOf("/"));
         String absoluteBasePath = psiManager.getProject().getBasePath();
@@ -24,6 +27,10 @@ public class SourceCodeFileResolver {
             }
         }
         return null;
+    }
+
+    private static boolean fqnHasDots(String fqn) {
+        return fqn.contains(".");
     }
 
     public static String getClassNameInSnakeCase(String fqn) {


### PR DESCRIPTION
Main PR: https://github.com/josemoren/pycharm-pypendency-plugin/pull/3

We are now handling some errors that appeared when trying to resolve FQNs without dots. For example, `container_builder.get("abc")`.