### PR TITLE
Fix NullPointerException in VirtualFile

### DIFF
--- a/src/main/java/org/fever/PythonReferenceProvider.java
+++ b/src/main/java/org/fever/PythonReferenceProvider.java
@@ -1,5 +1,6 @@
 package org.fever;
 
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.util.QualifiedName;
 import com.intellij.util.ProcessingContext;
@@ -26,7 +27,11 @@ public class PythonReferenceProvider extends ReferenceProvider {
     }
 
     private static boolean isInDependencyInjectionFile(@NotNull PsiElement element) {
-        String absoluteFilePath = element.getContainingFile().getVirtualFile().getCanonicalPath();
+        VirtualFile virtualFile = element.getContainingFile().getVirtualFile();
+        if (virtualFile == null) {
+            return false;
+        }
+        String absoluteFilePath = virtualFile.getCanonicalPath();
         if (absoluteFilePath == null) {
             return false;
         }


### PR DESCRIPTION
### 📖  Summary
This PR fixes an exception that was raised occasionally, as reported by some users:

```
java.lang.NullPointerException: Cannot invoke "com.intellij.openapi.vfs.VirtualFile.getCanonicalPath()" because the return value of "com.intellij.psi.PsiFile.getVirtualFile()" is null
	at org.fever.PythonReferenceProvider.isInDependencyInjectionFile(PythonReferenceProvider.java:29)
	at org.fever.PythonReferenceProvider.getReferencesByElement(PythonReferenceProvider.java:18)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistryImpl.getReferences(ReferenceProvidersRegistryImpl.java:184)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistryImpl.mapNotEmptyReferencesFromProviders(ReferenceProvidersRegistryImpl.java:165)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistryImpl.doGetReferencesFromProviders(ReferenceProvidersRegistryImpl.java:144)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry.lambda$getReferencesFromProviders$0(ReferenceProvidersRegistry.java:44)
	at com.intellij.psi.util.CachedValuesManager$1.compute(CachedValuesManager.java:158)
	at com.intellij.psi.impl.PsiCachedValueImpl.doCompute(PsiCachedValueImpl.java:37)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$3(CachedValueBase.java:240)
	at com.intellij.util.CachedValueBase.computeData(CachedValueBase.java:43)
	at com.intellij.util.CachedValueBase.lambda$getValueWithLock$4(CachedValueBase.java:240)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.openapi.util.RecursionGuard.doPreventingRecursion(RecursionGuard.java:27)
	at com.intellij.openapi.util.RecursionManager.doPreventingRecursion(RecursionManager.java:66)
	at com.intellij.util.CachedValueBase.getValueWithLock(CachedValueBase.java:241)
	at com.intellij.psi.impl.PsiCachedValueImpl.getValue(PsiCachedValueImpl.java:27)
	at com.intellij.util.CachedValuesManagerImpl.getCachedValue(CachedValuesManagerImpl.java:69)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:155)
	at com.intellij.psi.util.CachedValuesManager.getCachedValue(CachedValuesManager.java:121)
	at com.intellij.psi.impl.source.resolve.reference.ReferenceProvidersRegistry.getReferencesFromProviders(ReferenceProvidersRegistry.java:42)
	at com.jetbrains.python.psi.impl.PyStringLiteralExpressionImpl.getReferences(PyStringLiteralExpressionImpl.java:193)
	at com.jetbrains.python.psi.impl.PyBaseElementImpl.addReferences(PyBaseElementImpl.java:166)
	at com.jetbrains.python.psi.impl.PyBaseElementImpl.findReferenceAt(PyBaseElementImpl.java:146)
	at com.intellij.psi.AbstractFileViewProvider.findReferenceAt(AbstractFileViewProvider.java:226)
	at com.intellij.psi.SingleRootFileViewProvider.findReferenceAt(SingleRootFileViewProvider.java:222)
	at com.intellij.psi.impl.source.PsiFileImpl.findReferenceAt(PsiFileImpl.java:525)
	at com.intellij.codeInsight.completion.CompletionUtil.findReferencePrefix(CompletionUtil.java:148)
	at com.intellij.codeInsight.completion.CompletionData.findPrefixStatic(CompletionData.java:129)
	at com.intellij.codeInsight.completion.CompletionData.findPrefixStatic(CompletionData.java:144)
	at com.intellij.codeInsight.completion.BaseCompletionService.suggestPrefix(BaseCompletionService.java:71)
	at com.intellij.codeInsight.completion.CompletionService.performCompletion(CompletionService.java:129)
	at com.intellij.codeInsight.completion.BaseCompletionService.performCompletion(BaseCompletionService.java:48)
	at com.intellij.codeInsight.completion.impl.CompletionServiceImpl.lambda$performCompletion$1(CompletionServiceImpl.java:345)
	at com.intellij.platform.diagnostic.telemetry.helpers.TraceKt.runWithSpan(trace.kt:80)
	at com.intellij.codeInsight.completion.impl.CompletionServiceImpl.performCompletion(CompletionServiceImpl.java:334)
	at com.intellij.codeInsight.completion.CompletionProgressIndicator.lambda$calculateItems$12(CompletionProgressIndicator.java:961)
	at com.intellij.util.indexing.FileBasedIndex.lambda$ignoreDumbMode$0(FileBasedIndex.java:219)
	at com.intellij.openapi.util.RecursionManager$1.computePreventingRecursion(RecursionManager.java:111)
	at com.intellij.util.indexing.FileBasedIndexEx.ignoreDumbMode(FileBasedIndexEx.java:644)
	at com.intellij.util.indexing.FileBasedIndex.ignoreDumbMode(FileBasedIndex.java:218)
	at com.intellij.util.indexing.DumbModeAccessType.ignoreDumbMode(DumbModeAccessType.java:43)
	at com.intellij.codeInsight.completion.CompletionProgressIndicator.calculateItems(CompletionProgressIndicator.java:957)
	at com.intellij.codeInsight.completion.CompletionProgressIndicator.runContributors(CompletionProgressIndicator.java:945)
	at com.intellij.codeInsight.completion.CodeCompletionHandlerBase.lambda$startContributorThread$7(CodeCompletionHandlerBase.java:378)
	at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:212)
	at com.intellij.codeInsight.completion.AsyncCompletion.lambda$tryReadOrCancel$5(CompletionThreading.java:162)
	at com.intellij.openapi.application.impl.ApplicationImpl.tryRunReadAction(ApplicationImpl.java:1075)
	at com.intellij.codeInsight.completion.AsyncCompletion.tryReadOrCancel(CompletionThreading.java:160)
	at com.intellij.codeInsight.completion.CodeCompletionHandlerBase.lambda$startContributorThread$8(CodeCompletionHandlerBase.java:369)
	at io.opentelemetry.context.Context.lambda$wrap$1(Context.java:212)
	at com.intellij.codeInsight.completion.AsyncCompletion.lambda$startThread$0(CompletionThreading.java:85)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$runProcess$1(CoreProgressManager.java:192)
	at com.intellij.openapi.progress.impl.CoreProgressManager.lambda$executeProcessUnderProgress$12(CoreProgressManager.java:610)
	at com.intellij.openapi.progress.impl.CoreProgressManager.registerIndicatorAndRun(CoreProgressManager.java:685)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computeUnderProgress(CoreProgressManager.java:641)
	at com.intellij.openapi.progress.impl.CoreProgressManager.executeProcessUnderProgress(CoreProgressManager.java:609)
	at com.intellij.openapi.progress.impl.ProgressManagerImpl.executeProcessUnderProgress(ProgressManagerImpl.java:78)
	at com.intellij.openapi.progress.impl.CoreProgressManager.runProcess(CoreProgressManager.java:179)
	at com.intellij.codeInsight.completion.AsyncCompletion.lambda$startThread$1(CompletionThreading.java:81)
	at com.intellij.openapi.application.impl.ApplicationImpl$2.run(ApplicationImpl.java:249)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:702)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1$1.run(Executors.java:699)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.util.concurrent.Executors$PrivilegedThreadFactory$1.run(Executors.java:699)
	at java.base/java.lang.Thread.run(Thread.java:840)
```