### PR TITLE
Bump version to 2024.1+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.fever'
-version '2023.3.1'
+version '2024.1'
 
 repositories {
     mavenCentral()
@@ -16,12 +16,12 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version='2023.3'
+    version='2024.1+'
     type='PY'
     plugins=['yaml', 'Pythonid']
     pluginName='pycharm-pypendency'
     downloadSources=false
 }
 patchPluginXml {
-    changeNotes="Version 2023.3.1<br>Go to pypendency."
+    changeNotes="Version 2024.1<br>Go to pypendency."
 }


### PR DESCRIPTION
### 📖  Summary
This PR updates the plugin so that it works in PyCharm 2024.1+

### 📱  How should this be manually tested?
- [ ] Compile the plugin and check it works:

![image](https://github.com/josemoren/pycharm-pypendency-plugin/assets/53608787/d70e9b14-8b63-491f-b74e-b998096edf31)

- [ ] Install the generated zip manually in your PyCharm 2024.1 installation:

![image](https://github.com/josemoren/pycharm-pypendency-plugin/assets/53608787/5a10b1da-7b8d-44f7-bbb9-75d294e81416)
