### PR TITLE
Allow detection of split identifiers

### DIFF
--- a/src/main/java/org/fever/ReferenceProvider.java
+++ b/src/main/java/org/fever/ReferenceProvider.java
@@ -10,13 +10,12 @@ public abstract class ReferenceProvider extends PsiReferenceProvider {
 
     @NotNull
     protected String cleanText(String text) {
-        return text.replaceAll("[\"']", "");
+        return text.replaceAll("[\"']|\\n+\\s*", "");
     }
 
     @NotNull
     protected static org.fever.PsiReference getReferenceForIdentifier(@NotNull PsiElement element, String identifier) {
-        TextRange range;
-        range = new TextRange(1, identifier.length() + 1);
+        TextRange range = new TextRange(1, element.getTextRangeInParent().getLength() - 1);
         return new org.fever.PsiReference(element, range, identifier);
     }
 }


### PR DESCRIPTION
### 📖  Summary
This PR improves the following aspects:
* Allow "⌘ + click" in identifiers made of several strings (often very longs identifiers which are auto-formatted) like this one:
```python
container_builder.get(
    "core.application.this.is.a"
    ".very_long_indentifier.which"
    ".WasSplitInSeveralLines"
)
```

* Fix a visual bug in which, sometimes, "⌘ + hovering" over a identifier would highlight the `"` at the beginning or the end of the identifier
