### PR TITLE
Extract DI file creation logic to separate files

### DIFF
--- a/src/main/java/org/fever/GotoPypendencyOrCodeHandler.java
+++ b/src/main/java/org/fever/GotoPypendencyOrCodeHandler.java
@@ -15,9 +15,10 @@ import com.intellij.openapi.vfs.VfsUtilCore;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.*;
 import com.intellij.util.SmartList;
+import org.fever.filecreator.PythonFileCreator;
+import org.fever.filecreator.YamlFileCreator;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.jetbrains.yaml.YAMLFileType;
 
 import javax.swing.*;
 import java.util.List;
@@ -105,7 +106,7 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
 
             @Override
             public void execute() {
-                self.createPypendencyYaml(editor, file);
+                self.createAndOpenYamlDIFile(editor, file);
             }
         });
 
@@ -123,7 +124,7 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
 
             @Override
             public void execute() {
-                self.createPypendencyPython(editor, file);
+                self.createAndOpenPythonDIFile(editor, file);
             }
         });
 
@@ -162,29 +163,20 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
         return null;
     }
 
-    private void createPypendencyYaml(Editor editor, PsiFile file) {
+    private void createAndOpenYamlDIFile(Editor editor, PsiFile file) {
         PsiDirectory directory = makePypendencyDirectoryForFile(file);
-        PsiFile psiFile = this.createYamlWithContent(editor, file);
+        PsiFile yamlDIFile = YamlFileCreator.create(
+                file.getProject(),
+                file.getName().replace(".py", ".yaml"),
+                this.getCurrentFQN(editor, file)
+        );
 
         PsiFile new_file = WriteAction.compute(
-                () -> (PsiFile) directory.add(psiFile)
+                () -> (PsiFile) directory.add(yamlDIFile)
         );
 
         Project fileProject = file.getProject();
         FileEditorManager.getInstance(fileProject).openFile(new_file.getVirtualFile(), true);
-    }
-
-    private PsiFile createYamlWithContent(Editor editor, PsiFile file) {
-        String fqn = this.getCurrentFQN(editor, file);
-        String yamlFileName = file.getName().replace(".py", ".yaml");
-        String yamlFileContent = fqn + ":\n    fqn: " + fqn;
-        Project fileProject = file.getProject();
-
-        return PsiFileFactory.getInstance(fileProject).createFileFromText(
-                yamlFileName,
-                YAMLFileType.YML,
-                yamlFileContent
-        );
     }
 
     private PsiDirectory makePypendencyDirectoryForFile(PsiFile file) {
@@ -204,46 +196,16 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
         );
     }
 
-    private void createPypendencyPython(Editor editor, PsiFile file) {
+    private void createAndOpenPythonDIFile(Editor editor, PsiFile file) {
         PsiDirectory directory = makePypendencyDirectoryForFile(file);
-        PsiFile psiFile = this.createPythonFileWithContent(editor, file);
+        String fqn = this.getCurrentFQN(editor, file);
+        PsiFile pythonDIFile = PythonFileCreator.create(file.getProject(), file.getName(), fqn);
 
         PsiFile new_file = WriteAction.compute(
-                () -> (PsiFile) directory.add(psiFile)
+                () -> (PsiFile) directory.add(pythonDIFile)
         );
         Project fileProject = file.getProject();
         FileEditorManager.getInstance(fileProject).openFile(new_file.getVirtualFile(), true);
-    }
-
-    private PsiFile createPythonFileWithContent(Editor editor, PsiFile file) {
-        String fqn = this.getCurrentFQN(editor, file);
-
-        String text = "from pypendency.argument import Argument\n" +
-                "from pypendency.builder import ContainerBuilder\n" +
-                "from pypendency.definition import Definition\n" +
-                "\n" +
-                "from django.conf import settings\n" +
-                "\n" +
-                "\n" +
-                "def load(container_builder: ContainerBuilder) -> None:\n" +
-                "    container_builder.set_definition(\n" +
-                "        Definition(\n" +
-                "            \"" + fqn + "\",\n" +
-                "            \"" + fqn + "\",\n" +
-                "            [\n" +
-                "                Argument.no_kw_argument(),\n" +
-                "            ],\n" +
-                "        )\n" +
-                "    )\n" +
-                "";
-
-        Project fileProject = file.getProject();
-
-        return PsiFileFactory.getInstance(fileProject).createFileFromText(
-                file.getName(),
-                YAMLFileType.YML,
-                text
-        );
     }
 
     private @Nullable VirtualFile getDIPath(@NotNull PsiFile file) {

--- a/src/main/java/org/fever/GotoPypendencyOrCodeHandler.java
+++ b/src/main/java/org/fever/GotoPypendencyOrCodeHandler.java
@@ -165,11 +165,8 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
 
     private void createAndOpenYamlDIFile(Editor editor, PsiFile file) {
         PsiDirectory directory = makePypendencyDirectoryForFile(file);
-        PsiFile yamlDIFile = YamlFileCreator.create(
-                file.getProject(),
-                file.getName().replace(".py", ".yaml"),
-                this.getCurrentFQN(editor, file)
-        );
+        String fqn = this.getCurrentFQN(editor, file);
+        PsiFile yamlDIFile = YamlFileCreator.create(file, fqn);
 
         PsiFile new_file = WriteAction.compute(
                 () -> (PsiFile) directory.add(yamlDIFile)
@@ -199,7 +196,7 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
     private void createAndOpenPythonDIFile(Editor editor, PsiFile file) {
         PsiDirectory directory = makePypendencyDirectoryForFile(file);
         String fqn = this.getCurrentFQN(editor, file);
-        PsiFile pythonDIFile = PythonFileCreator.create(file.getProject(), file.getName(), fqn);
+        PsiFile pythonDIFile = PythonFileCreator.create(file, fqn);
 
         PsiFile new_file = WriteAction.compute(
                 () -> (PsiFile) directory.add(pythonDIFile)

--- a/src/main/java/org/fever/filecreator/PythonFileCreator.java
+++ b/src/main/java/org/fever/filecreator/PythonFileCreator.java
@@ -1,6 +1,5 @@
 package org.fever.filecreator;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import com.jetbrains.python.PythonFileType;
@@ -26,12 +25,12 @@ public class PythonFileCreator {
                 )
                     """;
 
-    public static PsiFile create(Project project, String fileName, String fqn) {
+    public static PsiFile create(PsiFile sourceCodeFile, String fqn) {
         String baseContent = PYTHON_DI_FILE_CONTENT_TEMPLATE.replace("{fqn}", fqn);
         String contentWithArguments = baseContent.replace("{arguments}", getArguments());
 
-        return PsiFileFactory.getInstance(project).createFileFromText(
-                fileName,
+        return PsiFileFactory.getInstance(sourceCodeFile.getProject()).createFileFromText(
+                sourceCodeFile.getName(),
                 PythonFileType.INSTANCE,
                 contentWithArguments
         );

--- a/src/main/java/org/fever/filecreator/PythonFileCreator.java
+++ b/src/main/java/org/fever/filecreator/PythonFileCreator.java
@@ -1,0 +1,43 @@
+package org.fever.filecreator;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
+import com.jetbrains.python.PythonFileType;
+
+public class PythonFileCreator {
+    private static final String PYTHON_DI_FILE_CONTENT_TEMPLATE = """
+            from pypendency.argument import Argument
+            from pypendency.builder import ContainerBuilder
+            from pypendency.definition import Definition
+            
+            from django.conf import settings
+            
+            
+            def load(container_builder: ContainerBuilder) -> None:
+                container_builder.set_definition(
+                    Definition(
+                        "{fqn}",
+                        "{fqn}",
+                        [
+                            {arguments},
+                        ],
+                    )
+                )
+                    """;
+
+    public static PsiFile create(Project project, String fileName, String fqn) {
+        String baseContent = PYTHON_DI_FILE_CONTENT_TEMPLATE.replace("{fqn}", fqn);
+        String contentWithArguments = baseContent.replace("{arguments}", getArguments());
+
+        return PsiFileFactory.getInstance(project).createFileFromText(
+                fileName,
+                PythonFileType.INSTANCE,
+                contentWithArguments
+        );
+    }
+
+    private static String getArguments() {
+        return "Argument.no_kw_argument()";
+    }
+}

--- a/src/main/java/org/fever/filecreator/YamlFileCreator.java
+++ b/src/main/java/org/fever/filecreator/YamlFileCreator.java
@@ -1,0 +1,29 @@
+package org.fever.filecreator;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiFileFactory;
+import org.jetbrains.yaml.YAMLFileType;
+
+public class YamlFileCreator {
+    private static final String YAML_DI_FILE_CONTENT_TEMPLATE = """
+            {fqn}:
+                fqn: {fqn}
+                {arguments}
+            """;
+
+    public static PsiFile create(Project project, String fileName, String fqn) {
+        String baseContent = YAML_DI_FILE_CONTENT_TEMPLATE.replace("{fqn}", fqn);
+        String contentWithArguments = baseContent.replace("{arguments}", getArguments());
+
+        return PsiFileFactory.getInstance(project).createFileFromText(
+                fileName,
+                YAMLFileType.YML,
+                contentWithArguments
+        );
+    }
+
+    private static String getArguments() {
+        return "";
+    }
+}

--- a/src/main/java/org/fever/filecreator/YamlFileCreator.java
+++ b/src/main/java/org/fever/filecreator/YamlFileCreator.java
@@ -1,6 +1,5 @@
 package org.fever.filecreator;
 
-import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiFileFactory;
 import org.jetbrains.yaml.YAMLFileType;
@@ -9,15 +8,14 @@ public class YamlFileCreator {
     private static final String YAML_DI_FILE_CONTENT_TEMPLATE = """
             {fqn}:
                 fqn: {fqn}
-                {arguments}
             """;
 
-    public static PsiFile create(Project project, String fileName, String fqn) {
+    public static PsiFile create(PsiFile sourceCodeFile, String fqn) {
         String baseContent = YAML_DI_FILE_CONTENT_TEMPLATE.replace("{fqn}", fqn);
-        String contentWithArguments = baseContent.replace("{arguments}", getArguments());
+        String contentWithArguments = baseContent.concat(getArguments());
 
-        return PsiFileFactory.getInstance(project).createFileFromText(
-                fileName,
+        return PsiFileFactory.getInstance(sourceCodeFile.getProject()).createFileFromText(
+                sourceCodeFile.getName().replace(".py", ".yaml"),
                 YAMLFileType.YML,
                 contentWithArguments
         );


### PR DESCRIPTION
### 📖  Summary
🏕️ We intend to improve the way DI files are generated by autocompleting `args` whenever we can. For this, we'll start by extracting the logic for creating `.py` and `.yaml` files to their own files, so that `GoToPyPendencyOrCodeHandler.java` doesn't keep growing 🧯 

### ⚙️ How should this be manually tested?
- [x] Create a **Python** DI file for a source code file and check its contents are the same as in the old plugin version
- [x] Create a **YAML** DI file for a source code file and check its contents are the same as in the old plugin version