### PR TITLE
Add support for old PyCharm versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.fever'
-version '2024.1'
+version '2024.1.1'
 
 repositories {
     mavenCentral()
@@ -16,7 +16,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version='2024.1+'
+    version='2023.1+'
     type='PY'
     plugins=['yaml', 'Pythonid']
     pluginName='pycharm-pypendency'
@@ -24,4 +24,6 @@ intellij {
 }
 patchPluginXml {
     changeNotes="Version 2024.1<br>Go to pypendency."
+    sinceBuild='231'
+    untilBuild='251.*'
 }


### PR DESCRIPTION
Main PR: https://github.com/josemoren/pycharm-pypendency-plugin/pull/15

### 📖  Summary
This PR adds support for old PyCharm versions (2023+) and for all minors in PyCharm 2024, so that we don't have to release a new version every time there's a PyCharm update