### PR TITLE
Search for YAML dependency injection files

### DIFF
--- a/src/main/java/org/fever/fileresolver/DependencyInjectionSearchScope.java
+++ b/src/main/java/org/fever/fileresolver/DependencyInjectionSearchScope.java
@@ -1,8 +1,9 @@
-package org.fever;
+package org.fever.fileresolver;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.search.GlobalSearchScope;
+import org.fever.GotoPypendencyOrCodeHandler;
 import org.jetbrains.annotations.NotNull;
 
 public class DependencyInjectionSearchScope extends GlobalSearchScope {
@@ -14,15 +15,11 @@ public class DependencyInjectionSearchScope extends GlobalSearchScope {
     @Override
     public boolean contains(@NotNull VirtualFile file) {
         String filePath = file.getPath();
-        return isPythonFile(file) && fileIsInDependencyInjectionFolder(filePath) && fileIsNotInExternalLibraries(filePath);
+        return fileIsInDependencyInjectionFolder(filePath) && fileIsNotInExternalLibraries(filePath);
     }
 
     private static boolean fileIsInDependencyInjectionFolder(String filePath) {
         return filePath.contains(GotoPypendencyOrCodeHandler.DEPENDENCY_INJECTION_FOLDER);
-    }
-
-    private static boolean isPythonFile(@NotNull VirtualFile file) {
-        return file.getName().endsWith(".py");
     }
 
     private static boolean fileIsNotInExternalLibraries(String filePath) {


### PR DESCRIPTION
Main PR: https://github.com/josemoren/pycharm-pypendency-plugin/pull/15

### 📖  Summary
This PR adds removes the `isPythonFile()` constraint from the `DependencyInjectionSearchScope`, which was searching for DI files in the project. This is because, in a further PR, we are resolving identifiers to YAML files relying on the declarations inside the file instead of on their filename (more reliable).