### PR TITLE
Use ArrayList which allows mutability

### DIFF
--- a/src/main/java/org/fever/filecreator/ClassArgumentFetcher.java
+++ b/src/main/java/org/fever/filecreator/ClassArgumentFetcher.java
@@ -68,7 +68,7 @@ public class ClassArgumentFetcher {
                 .findAll()
                 .stream()
                 .map(PyClass::getName)
-                .collect(Collectors.toList());
+                .toList();
 
         allClassNames.addAll(implementationClassNames);
         return allClassNames;
@@ -86,7 +86,7 @@ public class ClassArgumentFetcher {
             return new HashMap<>();
         }
 
-        List<PyParameter> dunderInitMethodParameters = Arrays.asList(initMethod.getParameterList().getParameters());
+        List<PyParameter> dunderInitMethodParameters = new ArrayList<>(Arrays.asList(initMethod.getParameterList().getParameters()));
         dunderInitMethodParameters.remove(SELF_INDEX_IN_PARAMETER_LIST);
         
         Map<PyParameter, @Nullable PyClass> paramsToClasses = new OrderedHashMap<>();


### PR DESCRIPTION
### 📖  Summary
This PR fixed a problem derived from the use of `.remove()` over a `List<>` created via `Arrays.asList()`, which prevents users from creating DI files:

```
java.lang.UnsupportedOperationException
	at java.base/java.util.AbstractList.remove(AbstractList.java:167)
	at org.fever.filecreator.ClassArgumentFetcher.getClassesFromInitParams(ClassArgumentFetcher.java:90)
	at org.fever.filecreator.ClassArgumentFetcher.getFqnOfInitArguments(ClassArgumentFetcher.java:32)
	at org.fever.filecreator.DIFileCreator.getArguments(DIFileCreator.java:44)
	at org.fever.filecreator.DIFileCreator.create(DIFileCreator.java:28)
	at org.fever.GotoPypendencyOrCodeHandler.createAndOpenDIFIle(GotoPypendencyOrCodeHandler.java:127)
	at org.fever.GotoPypendencyOrCodeHandler$1.execute(GotoPypendencyOrCodeHandler.java:95)
```

This happens because `Arrays.asList` returns a `List` wrapper around an array. **This wrapper has a fixed size and is directly backed by the array**, and as such calls to `.remove()` will modify the array, any method that modifies the list will throw an `UnsupportedOperationException`.

To fix this, we can create a new modifiable list by copying the wrapper list's contents using the `ArrayList` constructor that takes a `Collection`