### PR TITLE
Handle files with multiple identifier declarations

### DIFF
--- a/src/main/java/org/fever/cachepopulator/PopulateCacheOnProjectStart.java
+++ b/src/main/java/org/fever/cachepopulator/PopulateCacheOnProjectStart.java
@@ -66,9 +66,12 @@ public class PopulateCacheOnProjectStart implements ProjectActivity {
                     if (!matcher.reset(fileContent).find()) {
                         continue;
                     }
-                    String identifier = matcher.group(1);
-                    String cleanIdentifier = identifier.replaceAll("[\"'@,]", "");
-                    resolutionCache.setCachedResolution(projectName, cleanIdentifier, file.getCanonicalPath());
+
+                    matcher.results().forEach(match -> {
+                        String identifier = match.group(1);
+                        String cleanIdentifier = identifier.replaceAll("[\"'@,]", "");
+                        resolutionCache.setCachedResolution(projectName, cleanIdentifier, file.getCanonicalPath());
+                    });
                 }
             }
         }

--- a/src/main/java/org/fever/cachepopulator/PopulateCacheOnProjectStart.java
+++ b/src/main/java/org/fever/cachepopulator/PopulateCacheOnProjectStart.java
@@ -62,16 +62,7 @@ public class PopulateCacheOnProjectStart implements ProjectActivity {
                     if (psiFile == null) {
                         continue;
                     }
-                    String fileContent = ReadAction.compute(psiFile::getText);
-                    if (!matcher.reset(fileContent).find()) {
-                        continue;
-                    }
-
-                    matcher.results().forEach(match -> {
-                        String identifier = match.group(1);
-                        String cleanIdentifier = identifier.replaceAll("[\"'@,]", "");
-                        resolutionCache.setCachedResolution(projectName, cleanIdentifier, file.getCanonicalPath());
-                    });
+                    cacheAllIdentifiersDefinedInFile(file, psiFile, matcher, projectName);
                 }
             }
         }
@@ -87,5 +78,15 @@ public class PopulateCacheOnProjectStart implements ProjectActivity {
 
     private static Collection<VirtualFile> getDependencyInjectionFiles(GlobalSearchScope scope, FileType fileType) {
         return ReadAction.compute(() -> FileBasedIndex.getInstance().getContainingFiles(FileTypeIndex.NAME, fileType, scope));
+    }
+
+    private static void cacheAllIdentifiersDefinedInFile(VirtualFile file, PsiFile psiFile, Matcher matcher, String projectName) {
+        String fileContent = ReadAction.compute(psiFile::getText);
+        matcher.reset(fileContent);
+        while (matcher.find()) {
+            String identifier = matcher.group(1);
+            String cleanIdentifier = identifier.replaceAll("[\"'@,]", "");
+            resolutionCache.setCachedResolution(projectName, cleanIdentifier, file.getCanonicalPath());
+        }
     }
 }

--- a/src/main/java/org/fever/filecreator/ClassArgumentFetcher.java
+++ b/src/main/java/org/fever/filecreator/ClassArgumentFetcher.java
@@ -76,7 +76,12 @@ public class ClassArgumentFetcher {
 
     private static @NotNull IdentifierItem getIdentifierItem(String className, Project project, PyParameter parameter, PyClass parameterClass) {
         PsiFile dependencyInjectionFile = DependencyInjectionFileResolverByClassName.resolve(project, className);
-        String implementationIdentifier = IdentifierExtractor.extractIdentifierFromDIFile(dependencyInjectionFile);
+        List<String> identifiersInDIFile = IdentifierExtractor.extractIdentifiersFromDIFile(dependencyInjectionFile);
+
+        String implementationIdentifier = identifiersInDIFile.stream()
+                .filter(identifier -> identifier.endsWith("." + className))
+                .findFirst()
+                .orElse(null);
         return new IdentifierItem(implementationIdentifier, parameterClass, parameter);
     }
 

--- a/src/main/java/org/fever/fileresolver/DependencyInjectionFileResolverByIdentifier.java
+++ b/src/main/java/org/fever/fileresolver/DependencyInjectionFileResolverByIdentifier.java
@@ -114,18 +114,20 @@ public class DependencyInjectionFileResolverByIdentifier {
                 continue;
             }
             String diFileContent = diFile.getText();
-            if (thereIsAnIdentifierDefinition(matcher, diFileContent) && identifierIsDefinedInFile(identifier, matcher)) {
+            if (identifierIsDefinedInFile(diFileContent, identifier, matcher)) {
                 return diFile;
             }
         }
         return null;
     }
 
-    private static boolean thereIsAnIdentifierDefinition(Matcher matcher, String diFileContent) {
-        return matcher.reset(diFileContent).find();
-    }
-
-    private static boolean identifierIsDefinedInFile(String identifier, Matcher matcher) {
-        return matcher.results().anyMatch(matchResult -> matchResult.group(1).equals(identifier));
+    private static boolean identifierIsDefinedInFile(String diFileContent, String identifier, Matcher matcher) {
+        matcher.reset(diFileContent);
+        while (matcher.find()) {
+            if (matcher.group(1).equals(identifier)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/org/fever/fileresolver/DependencyInjectionFileResolverByIdentifier.java
+++ b/src/main/java/org/fever/fileresolver/DependencyInjectionFileResolverByIdentifier.java
@@ -114,10 +114,18 @@ public class DependencyInjectionFileResolverByIdentifier {
                 continue;
             }
             String diFileContent = diFile.getText();
-            if (matcher.reset(diFileContent).find() && matcher.group(1).equals(identifier)) {
+            if (thereIsAnIdentifierDefinition(matcher, diFileContent) && identifierIsDefinedInFile(identifier, matcher)) {
                 return diFile;
             }
         }
         return null;
+    }
+
+    private static boolean thereIsAnIdentifierDefinition(Matcher matcher, String diFileContent) {
+        return matcher.reset(diFileContent).find();
+    }
+
+    private static boolean identifierIsDefinedInFile(String identifier, Matcher matcher) {
+        return matcher.results().anyMatch(matchResult -> matchResult.group(1).equals(identifier));
     }
 }

--- a/src/main/java/org/fever/utils/IdentifierExtractor.java
+++ b/src/main/java/org/fever/utils/IdentifierExtractor.java
@@ -3,6 +3,7 @@ package org.fever.utils;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -11,28 +12,33 @@ public class IdentifierExtractor {
     private static final String PYTHON_IDENTIFIER_GROUP_SELECTOR_REGEX = "container_builder\\.set_definition\\(\\s+Definition\\(\\s*\"(\\S+)\",\\s*\"\\S+\"";
     private static final String PYTHON_IDENTIFIER_GROUP_SELECTOR_DEFINED_MANUALLY_REGEX = "container(?:_builder)?\\.set\\(\\s*\"(\\S+)\"";
 
-    private static @Nullable String extractGroupFromRegex(String text, String regex) {
+    private static @Nullable List<String> extractGroupMatchesFromRegex(String text, String regex) {
         Matcher matcher = Pattern.compile(regex).matcher(text);
-        return matcher.find() ? matcher.group(1) : null;
+        if (!matcher.find()) {
+            return null;
+        }
+        return matcher.results().map(matchResult -> matchResult.group(1)).toList();
     }
 
-    public static @Nullable String extractIdentifierFromDIFile(@Nullable PsiFile dependencyInjectionFile) {
+    public static List<String> extractIdentifiersFromDIFile(@Nullable PsiFile dependencyInjectionFile) {
+        List<String> EMPTY_LIST = List.of();
+
         if (dependencyInjectionFile == null) {
-            return null;
+            return EMPTY_LIST;
         }
         String extension = dependencyInjectionFile.getVirtualFile().getExtension();
         if (extension == null) {
-            return null;
+            return EMPTY_LIST;
         }
 
         String fileContent = dependencyInjectionFile.getText();
         if (isYamlFile(extension)) {
-            return extractIdentifierFromYaml(fileContent);
+            return extractIdentifiersFromYaml(fileContent);
         }
         if (isPythonFile(extension)) {
-            return extractIdentifierFromPython(fileContent);
+            return extractIdentifiersFromPython(fileContent);
         }
-        return null;
+        return EMPTY_LIST;
     }
 
     public static Boolean isYamlFile(String extension) {
@@ -44,15 +50,15 @@ public class IdentifierExtractor {
     }
 
 
-    public static @Nullable String extractIdentifierFromYaml(String fileContent) {
-        return extractGroupFromRegex(fileContent, YAML_IDENTIFIER_GROUP_SELECTOR_REGEX);
+    public static @Nullable List<String> extractIdentifiersFromYaml(String fileContent) {
+        return extractGroupMatchesFromRegex(fileContent, YAML_IDENTIFIER_GROUP_SELECTOR_REGEX);
     }
 
-    public static @Nullable String extractIdentifierFromPython(String fileContent) {
+    public static @Nullable List<String> extractIdentifiersFromPython(String fileContent) {
         for (String regex : new String[]{PYTHON_IDENTIFIER_GROUP_SELECTOR_REGEX, PYTHON_IDENTIFIER_GROUP_SELECTOR_DEFINED_MANUALLY_REGEX}) {
-            String identifier = extractGroupFromRegex(fileContent, regex);
-            if (identifier != null) {
-                return identifier;
+            List<String> identifiers = extractGroupMatchesFromRegex(fileContent, regex);
+            if (identifiers != null) {
+                return identifiers;
             }
         }
         return null;

--- a/src/main/java/org/fever/utils/IdentifierExtractor.java
+++ b/src/main/java/org/fever/utils/IdentifierExtractor.java
@@ -3,6 +3,7 @@ package org.fever.utils;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -14,10 +15,11 @@ public class IdentifierExtractor {
 
     private static @Nullable List<String> extractGroupMatchesFromRegex(String text, String regex) {
         Matcher matcher = Pattern.compile(regex).matcher(text);
-        if (!matcher.find()) {
-            return null;
+        List<String> allGroupMatches = new ArrayList<>();
+        while (matcher.find()) {
+            allGroupMatches.add(matcher.group(1));
         }
-        return matcher.results().map(matchResult -> matchResult.group(1)).toList();
+        return allGroupMatches.isEmpty() ? null : allGroupMatches;
     }
 
     public static List<String> extractIdentifiersFromDIFile(@Nullable PsiFile dependencyInjectionFile) {


### PR DESCRIPTION
### 📖  Summary
This PR adds support for DI files that have more than one `container_builder.set()` in them. Instead of returning the first match by the regex, the code returns a list of all identifiers and iterates over them.

### 📱  How should this be manually tested?

- [ ] Try to ⌘+Click an identifier whose DI file contains more than one `container_builder.set()` (think about Django managers) and check it works
- [ ] Try to create the DI file of a class which injects these kind of identifiers and check that they are properly autocompleted
- [ ] Check that smart autocompletion in DI files contains all Django managers (to check that they were populated to the cache)