### PR TITLE
Don't initialize cache instance in constructor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.fever'
-version '2024.1.1'
+version '2024.1.2'
 
 repositories {
     mavenCentral()

--- a/src/main/java/org/fever/CompletionContributor.java
+++ b/src/main/java/org/fever/CompletionContributor.java
@@ -15,12 +15,12 @@ import java.util.List;
 
 public class CompletionContributor extends com.intellij.codeInsight.completion.CompletionContributor {
     private static final String INTELLIJ_DEFAULT_STRING = "IntellijIdeaRulezzz "; // https://intellij-support.jetbrains.com/hc/en-us/community/posts/4411826210066-How-to-deal-with-INTELLIJIDEARULEZZZ-in-Reference-Code-Completion
-    private static final ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
     public CompletionContributor() {
     }
 
     @Override
     public void fillCompletionVariants(@NotNull CompletionParameters parameters, @NotNull CompletionResultSet result) {
+        ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
         PsiElement element = parameters.getPosition().getContainingFile().findElementAt(parameters.getOffset());
         if (!isDependencyInjectionStatement(element)) {
             return;

--- a/src/main/java/org/fever/GotoPypendencyOrCodeHandler.java
+++ b/src/main/java/org/fever/GotoPypendencyOrCodeHandler.java
@@ -34,8 +34,6 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
     public static final String DEPENDENCY_INJECTION_FOLDER = "/_dependency_injection/";
     AnActionEvent anActionEvent;
 
-    private static final ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
-
     public GotoPypendencyOrCodeHandler(AnActionEvent anActionEvent) {
         super();
         this.anActionEvent = anActionEvent;
@@ -134,6 +132,7 @@ public class GotoPypendencyOrCodeHandler extends GotoTargetHandler {
         }
 
         String createdFilePath = newFile.getVirtualFile().getCanonicalPath();
+        ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
         resolutionCache.setCachedResolution(file.getProject().getName(), fqn, createdFilePath);
         Project fileProject = file.getProject();
         FileEditorManager.getInstance(fileProject).openFile(newFile.getVirtualFile(), true);

--- a/src/main/java/org/fever/cachepopulator/PopulateCacheOnProjectStart.java
+++ b/src/main/java/org/fever/cachepopulator/PopulateCacheOnProjectStart.java
@@ -41,11 +41,10 @@ public class PopulateCacheOnProjectStart implements ProjectActivity {
                     })
     };
 
-    private static final ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
-
     @Nullable
     @Override
     public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
+        ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
         PsiManager psiManager = PsiManager.getInstance(project);
         String projectName = project.getName();
         GlobalSearchScope scope = GlobalSearchScope.projectScope(psiManager.getProject());
@@ -75,6 +74,7 @@ public class PopulateCacheOnProjectStart implements ProjectActivity {
     }
 
     private static void cacheAllIdentifiersDefinedInFile(VirtualFile file, PsiFile psiFile, Matcher matcher, String projectName) {
+        ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
         String fileContent = ReadAction.compute(psiFile::getText);
         matcher.reset(fileContent);
         while (matcher.find()) {

--- a/src/main/java/org/fever/fileresolver/DependencyInjectionFileResolverByClassName.java
+++ b/src/main/java/org/fever/fileresolver/DependencyInjectionFileResolverByClassName.java
@@ -10,10 +10,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 
 public class DependencyInjectionFileResolverByClassName {
-    private static final ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
     private static final Logger LOG = Logger.getInstance("Pypendency");
 
     private static PsiFile resolveFromCache(PsiManager manager, String identifier) {
+        ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
         String projectName = manager.getProject().getName();
         String cachedFilePath = resolutionCache.getCachedResolution(projectName, identifier);
         if (cachedFilePath == null) {
@@ -32,6 +32,7 @@ public class DependencyInjectionFileResolverByClassName {
     }
 
     public static PsiFile resolve(Project project, String className) {
+        ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
         PsiManager psiManager = PsiManager.getInstance(project);
         String projectName = project.getName();
         Collection<String> possibleIdentifiers = resolutionCache.getCachedIdentifiersByClassName(projectName, className);

--- a/src/main/java/org/fever/fileresolver/DependencyInjectionFileResolverByIdentifier.java
+++ b/src/main/java/org/fever/fileresolver/DependencyInjectionFileResolverByIdentifier.java
@@ -21,7 +21,6 @@ public class DependencyInjectionFileResolverByIdentifier {
             "container_builder\\.set_definition\\(\\s*Definition\\(\\s*\"(\\S+)\"",
     };
     private static final String REGEX_FOR_YAML_DI_FILES = "^(\\S+):\n\\s*fqn:";
-    private static final ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
     private static final Logger LOG = Logger.getInstance("Pypendency");
 
     /**
@@ -44,6 +43,7 @@ public class DependencyInjectionFileResolverByIdentifier {
     }
 
     private static PsiFile resolveFromCache(PsiManager manager, String identifier) {
+        ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
         String projectName = manager.getProject().getName();
         String cachedFilePath = resolutionCache.getCachedResolution(projectName, identifier);
         if (cachedFilePath == null) {
@@ -62,6 +62,7 @@ public class DependencyInjectionFileResolverByIdentifier {
 
     @Nullable
     private static PsiFile resolveManuallyAndStoreInCache(PsiManager psiManager, String identifier) {
+        ResolutionCache.State resolutionCache = ResolutionCache.getInstance();
         PsiFile file = resolveToDependencyInjectionManualDeclaration(identifier, psiManager);
 
         if (file == null) {


### PR DESCRIPTION
### 📖  Summary
@rafagcfever detected the following error when opening a project in PyCharm 2024.2:

```
java.lang.Throwable: org.fever.cachepopulator.PopulateCacheOnProjectStart <clinit> requests org.fever.ResolutionCache instance. Class initialization must not depend on services. Consider using instance of the service on-demand instead.
	at com.intellij.openapi.diagnostic.Logger.error(Logger.java:376)
	at com.intellij.serviceContainer.ComponentManagerImplKt.checkOutsideClassInitializer(ComponentManagerImpl.kt:1588)
	at com.intellij.serviceContainer.ComponentManagerImplKt.getOrCreateInstanceBlocking(ComponentManagerImpl.kt:1557)
	at com.intellij.serviceContainer.ComponentManagerImpl.doGetService(ComponentManagerImpl.kt:746)
	at com.intellij.serviceContainer.ComponentManagerImpl.getService(ComponentManagerImpl.kt:690)
	at org.fever.ResolutionCache.getInstance(ResolutionCache.java:71)
	at org.fever.cachepopulator.PopulateCacheOnProjectStart.<clinit>(PopulateCacheOnProjectStart.java:44)
	at java.base/jdk.internal.misc.Unsafe.allocateInstance(Native Method)
	at java.base/java.lang.invoke.DirectMethodHandle.allocateInstance(DirectMethodHandle.java:501)
(...)
```

The problem comes from initializing the cache service during the class initialization, as described by the error message. This PR fixes it by moving the `getInstance()` statement inside the function where it's used. **It doesn't break the plugin, it still works**, but the initial cache isn't populated and it adds the annoying error message.

> [!NOTE]
> This seems to be affecting all plugins of the JetBrains ecosystem in 2024.2 versions, as it also happened in `google-java-format` https://github.com/google/google-java-format/issues/1132.

###  How should this be manually tested?
- [ ] **With the latest marketplace plugin version**, open a project in PyCharm 2024.2 and check an IDE error popup appears in the bottom right corner of the window
- [ ] Install the new plugin version from this PR:

![image](https://github.com/user-attachments/assets/31559e7c-5276-4373-a0b5-455e6c2afd93)

- [ ] **With the version attached to this PR**, open a project in PyCharm 2024.2 and check it works without errors
