### PR TITLE
Replace use of deprecated API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.fever'
-version '2024.1.1'
+version '2024.3.0'
 
 repositories {
     mavenCentral()
@@ -23,7 +23,7 @@ intellij {
     downloadSources=false
 }
 patchPluginXml {
-    changeNotes="Version 2024.1<br>Go to pypendency."
+    changeNotes="Version 2024.3<br>Go to pypendency."
     sinceBuild='231'
     untilBuild='251.*'
 }

--- a/src/main/java/org/fever/GotoPypendencyOrCodeAction.java
+++ b/src/main/java/org/fever/GotoPypendencyOrCodeAction.java
@@ -5,6 +5,7 @@ import com.intellij.codeInsight.generation.actions.PresentableActionHandlerBased
 import com.intellij.lang.CodeInsightActions;
 import com.intellij.lang.LanguageExtension;
 import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.DataKey;
 import com.intellij.openapi.actionSystem.Presentation;
 import com.intellij.psi.PsiFile;
 import org.jetbrains.annotations.NotNull;
@@ -20,7 +21,7 @@ public class GotoPypendencyOrCodeAction extends PresentableActionHandlerBasedAct
     @Override
     @NotNull
     protected CodeInsightActionHandler getHandler(){
-        PsiFile file = (PsiFile) this.anActionEvent.getDataContext().getData("psi.File");
+        PsiFile file = this.anActionEvent.getData(DataKey.create("psi.File"));
         assert file != null;
         if (isDependencyInjectionFile(file)) {
             return new GotoCodeHandler(this.anActionEvent);


### PR DESCRIPTION
### 📖  Summary
This PR fixes the use of a deprecated API that will be removed in JetBrains IDEs 2024.3+. **This change makes the plugin compatible with future versions**.

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/9c3c4b17-15fa-424f-87c1-2c5a27a3f5a4">

### 📱  How should this be manually tested?
- [ ] Put a breakpoint here and run the project with the `runIde` configuration in debug mode:
![image](https://github.com/user-attachments/assets/c21e3879-2d7a-4e8e-bb84-b1f530dc16f4)

- [ ] Use the PyPendency action to "Go to/create DI file" and check the breakpoint stops
<img width="646" alt="image" src="https://github.com/user-attachments/assets/6c561228-378e-4fa7-803b-f421aa1fa707">

- [ ] Check that the value of the `file` variable is the Python file where you're calling the action from and the action works as expected
