### PR TITLE
Support all future builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 group 'org.fever'
-version '2024.3.0'
+version '2024.3.1'
 
 repositories {
     mavenCentral()
@@ -25,5 +25,4 @@ intellij {
 patchPluginXml {
     changeNotes="Version 2024.3<br>Go to pypendency."
     sinceBuild='231'
-    untilBuild='251.*'
 }


### PR DESCRIPTION
### 📖 Summary
This PR removes the `untilBuild` value, **making it unlimited**, as stated [here](https://intellij-support.jetbrains.com/hc/en-us/community/posts/21616053410194/comments/21618953590034):

<img width="662" alt="image" src="https://github.com/user-attachments/assets/5d19cc93-bce1-48d8-81e2-a9c5c6d66b7f" />
