### PR TITLE
Improve Gradle compatibility and bump versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,11 @@
 plugins {
     id 'java'
-    id 'org.jetbrains.intellij' version '1.13.0'
+    id 'org.jetbrains.intellij' version '1.17.4'
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 group 'org.fever'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR adds the `sourceCompatibility` and `targetCompatibility` tags to the `build.gradle` file to specify the Java version used in the project.

In addition, the following parts of the code have a bump version:
- gradle-wrapper: `8.14`
- IntelliJ plugin: `1.17.4`