### PR TITLE
Support all future builds (the expected way for build.gradle)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,4 +25,5 @@ intellij {
 patchPluginXml {
     changeNotes="Version 2024.3<br>Go to pypendency."
     sinceBuild='231'
+    untilBuild=provider{null}
 }


### PR DESCRIPTION
## 📖 Summary
We merged [this](https://github.com/josemoren/pycharm-pypendency-plugin/pull/29) a while ago, but the uploaded version didn't have an unlimited upper bound for versions as we expected.

As stated [here](https://intellij-support.jetbrains.com/hc/en-us/community/posts/21616053410194/comments/21692503752594), this PR sets the version to `provider {null}`, which is explicit, and the way supported by `build.gradle`:

| Before | After |
| - | - |
| ![image](https://github.com/user-attachments/assets/94d0fc42-e138-4cf2-b729-2aebd4ccd078) | ![image](https://github.com/user-attachments/assets/efbbe04e-19b8-470d-9afd-0760c9a38f76) |

