### PR TITLE
Render YAML DI icon on the fqn line

### DIFF
--- a/src/main/java/org/fever/provider/YamlLineMarkerProvider.java
+++ b/src/main/java/org/fever/provider/YamlLineMarkerProvider.java
@@ -37,8 +37,7 @@ public class YamlLineMarkerProvider extends LineMarkerProviderDescriptor {
             return null;
         }
 
-        PsiElement firstElement = file.findElementAt(0);
-        if (psiElement != firstElement) {
+        if (!"fqn".equals(psiElement.getText())) {
             return null;
         }
 


### PR DESCRIPTION
This PR moves the icon from the YAML file to the line with the `fqn`.

| Before | After |
|--------|--------|
| <img width="558" alt="image" src="https://github.com/user-attachments/assets/c7b39a8d-ab51-4131-9da0-02c6d8b8883f" /> | <img width="438" alt="image" src="https://github.com/user-attachments/assets/ff45a5c7-4e82-4776-b8a1-ebcd8ffef8b1" /> |