### PR TITLE
Fix: remove lowercase map from `fuzzyFindIdentifiersMatching`

### DIFF
--- a/src/main/java/org/fever/ResolutionCache.java
+++ b/src/main/java/org/fever/ResolutionCache.java
@@ -54,8 +54,7 @@ public final class ResolutionCache implements PersistentStateComponent<Resolutio
             return this.getResolutionCacheForProject(projectName)
                 .keySet()
                 .stream()
-                .map(String::toLowerCase)
-                .filter(key -> key.contains(identifier.toLowerCase()))
+                .filter(key -> key.toLowerCase().contains(identifier.toLowerCase()))
                 .toList();
         }
     }


### PR DESCRIPTION
When calling the `container_builder.get` method, the reference is completed with lowercase.